### PR TITLE
add set_guid method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+/.idea

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -312,6 +312,11 @@ impl Adapter {
         get_adapter_name(&self.wintun, self.adapter.0)
     }
 
+    /// Set guid for current adapter. This is a workaround.
+    pub fn set_guid(&mut self, guid:u128) {
+        self.guid = guid;
+    }
+
     /// Returns the Win32 interface index of this adapter. Useful for specifying the interface
     /// when executing `netsh interface ip` commands
     pub fn get_adapter_index(&self) -> Result<u32, error::WintunError> {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -312,7 +312,8 @@ impl Adapter {
         get_adapter_name(&self.wintun, self.adapter.0)
     }
 
-    /// Set guid for current adapter. This is a workaround.
+    /// Set GUID for current adapter. This is a workaround for [`Adapter::get_adapter_index`] to work right.
+    /// Notice: This won't change the GUID of the current adapter.
     pub fn set_guid(&mut self, guid:u128) {
         self.guid = guid;
     }


### PR DESCRIPTION
This is a workaround. There is no way to get guid from opening yet, and no way to set guid to make get_adapter_index right. So a set_guid is a quick fix.