### PR TITLE
feat: add ShuttingDown error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
 
     #[error(transparent)]
     Infallible(#[from] std::convert::Infallible),
+
+    #[error("Session {0:?} shutting down")]
+    ShuttingDown(String),
 }
 
 impl From<String> for Error {

--- a/src/session.rs
+++ b/src/session.rs
@@ -136,8 +136,8 @@ impl Session {
                         continue;
                     } else if result.0 == WAIT_OBJECT_0.0 + 1 {
                         //Shutdown event triggered
-                        let err = format!("Session {:?} shuting down", self.session);
-                        return Err(Error::from(err));
+                        let session_id = format!("{:?}", self.session);
+                        return Err(Error::ShuttingDown(session_id));
                     }
                 }
             }


### PR DESCRIPTION
This will make it easier to catch the shutdown message and cleanly exit e.g. a worker thread or Tokio task that's in `receive_blocking`, without needing to match the string exactly and without ignoring other types of errors.