### PR TITLE
Prep 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.4.0] - 2024-01-12
+
+## Added
+- `Adapter::get_mtu`, `set_dns_servers`, and `Adapter::get_active_network_interface_gateways`: https://github.com/nulldotblack/wintun/pull/13
+- `Error::ShuttingDown`: https://github.com/nulldotblack/wintun/pull/14
+
+### Breaking Changes
+- Adding the `ShuttingDown` variant to `wintun::Error` breaks exhastive matches on previous versions. `wintun::Error` is now marked `#[non_exhaustive]` to make future additions backwards compatable
+
 ## [0.3.2] - 2023-09-27
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wintun"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 authors = [
     "null.black Inc. <opensource@null.black>",

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub struct OutOfRangeData<T> {
 
 /// Error type returned when preconditions of this API are broken
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
## [0.4.0] - 2024-01-12

## Added
- `Adapter::get_mtu`, `set_dns_servers`, and `Adapter::get_active_network_interface_gateways`: https://github.com/nulldotblack/wintun/pull/13
- `Error::ShuttingDown`: https://github.com/nulldotblack/wintun/pull/14

### Breaking Changes
- Adding the `ShuttingDown` variant to `wintun::Error` breaks exhastive matches on previous versions. `wintun::Error` is now marked `#[non_exhaustive]` to make future additions backwards compatable